### PR TITLE
Log JSON::RPC2::TwoWay debug output to the log

### DIFF
--- a/lib/RPC/Switch/Client.pm
+++ b/lib/RPC/Switch/Client.pm
@@ -1,7 +1,7 @@
 package RPC::Switch::Client;
 use Mojo::Base 'Mojo::EventEmitter';
 
-our $VERSION = '0.21'; # VERSION
+our $VERSION = '0.22'; # VERSION
 
 #
 # Mojo's default reactor uses EV, and EV does not play nice with signals


### PR DESCRIPTION
Log the debugging output of JSON::RPC2::TwoWay to the log. 

NOTES

In testing I was able to make JSON::RPC2::TwoWay outlive the client so a fallback mode was needed. Also calling `$client->close` causes the log to go away so this had to be accommodated.
